### PR TITLE
Maintain all JSONPaths on failure to commit

### DIFF
--- a/aeson-commit.cabal
+++ b/aeson-commit.cabal
@@ -37,7 +37,7 @@ test-suite tasty
     Data.Aeson.CommitTest
   build-depends:
       base
-    , aeson
+    , aeson >= 1.4.6.0
     , aeson-qq
     , aeson-commit
     , containers

--- a/src/Data/Aeson/Commit.hs
+++ b/src/Data/Aeson/Commit.hs
@@ -1,12 +1,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Data.Aeson.Commit where
+module Data.Aeson.Commit
+  ( commit
+  , runCommit
+  , Commit(..)
+  , formatFail
+  , failList
+  , tryParser
+  , liftParser
+  , (.:>)
+  ) where
 
 import           Control.Applicative  (Alternative (..))
 import           Control.Monad.Except
 import           Data.Aeson.Types
-import           Data.Text            (Text)
-import           Data.Void            (Void, absurd)
+import           Data.Char            (isAlpha, isAlphaNum)
+import           Data.Text            (Text, unpack)
+import           Data.Void            (Void, vacuous)
 
 -- | A parser that has _two_ failure modes; the 'ExceptT' or in the underlying 'Parser'.
 --   The alternative instance only recovers from failures in the `ExceptT`.
@@ -19,28 +29,17 @@ newtype Commit a = Commit {unCommit :: ExceptT [Parser Void] Parser a}
 -- | Construct a commit.
 --   If the first parser succeeds, the 'Commit' is a success, and any failures in the inner action will be preserved.
 commit :: Parser a -> (a -> Parser b) -> Commit b
-commit pre post = Commit $ do
-  a <- ExceptT $ captureError pre -- Lift pre's error to the ExceptT level
-  lift $ post a
+commit pre post
+  = Commit $ ExceptT (captureError pre) -- Lift pre's error to the ExceptT level
+  >>= lift . post -- Keep post's error in the inner (committed) Parser
     where
       captureError :: Parser b -> Parser (Either [Parser Void] b)
       captureError p = Right <$> p <|> pure (Left [fmap (const undefined) p])
 
+-- | Run a 'Commit' parser. If the 'Commit' parser fails to commit the error
+-- messages in the resulting parser are formatted with the 'failList' function.
 runCommit :: Commit a -> Parser a
-runCommit (Commit f) = runExceptT f >>= either handleErrors pure
-  where
-  handleErrors :: [Parser Void] -> Parser a
-  handleErrors []     = fail "No parsers tried"
-  handleErrors (p:ps) = fmap absurd (go (p:ps) [] [])
-    where
-    go [] path errors = parserThrowError path ("No match,\n" <> unlines (fmap ("- " <>) errors))
-    go (y:ys) _ msgs = parserCatchError y $ \path msg ->
-      go ys path (msg:msgs)
-        -- TODO: how do we handle the multiple JSONPaths?
-        -- Right now the rightmost failure's path is used when presenting
-        -- the error message. Ideally one path per error would be preferable but
-        -- `aeson` doesn't support such a thing. When errors are reported in `aeson`
-        -- a single JSONPath defines how the error message is presented.
+runCommit (Commit (ExceptT e)) = e >>= either (formatFail failList) pure
 
 -- | Convenience wrapper around 'commit' for when the commit is simply checking whether a key is present in some object.
 --   If it is, it will append the key to the JSONPath of the inner context through '<?>'.
@@ -61,3 +60,70 @@ tryParser p = commit p pure
 -- > liftParser p = commit (pure ()) (\() -> p) = Commit (lift p)
 liftParser :: Parser a -> Commit a
 liftParser p = commit (pure ()) (const p)
+
+-- | Format the error messages from the passed 'Parser's.
+formatFail
+  :: ([(JSONPath, String)] -> (JSONPath, String))
+  -> [Parser Void]
+  -> Parser a
+formatFail f = handleErrors
+  where
+  handleErrors :: [Parser Void] -> Parser a
+  handleErrors ps = vacuous (go ps [])
+    where
+    go [] errors =
+      let (path, error) = f (reverse errors)
+      in parserThrowError path error
+    go (y:ys) msgs = parserCatchError y $ \path msg ->
+      go ys ((path,msg):msgs)
+
+-- | Output the many errors as a YAML encoded list. If the error
+-- messages have different 'JSONPath's then the longest common prefix
+-- is used in the top-level error message and the non-empty relative paths
+-- from the top-level path is shown at the respective error message.
+failList :: [(JSONPath, String)] -> (JSONPath, String)
+failList [] = ([], "No parsers tried")
+failList [(path, msg)] = (path, msg)
+failList errors =
+  let (paths, msgs) = unzip errors
+      common = commonPrefix paths
+      relative = fmap (drop (length common)) paths
+  in (common, "No match,\n" <> unlines (zipWith showError relative msgs))
+  where
+  showError [] msg  = "- " <> msg
+  showError rel msg = "- " <> formatRelativePath rel <> ": " <> msg
+  commonPrefix :: Eq a => [[a]] -> [a]
+  commonPrefix []     = []
+  commonPrefix (x:xs) = foldr common x xs
+    where
+    common as bs = fst <$> takeWhile (uncurry (==)) (zip as bs)
+
+-- | Format a <http://goessner.net/articles/JsonPath/ JSONPath> as a 'String'
+-- which represents the path relative to some root object.
+--
+-- The function is exposed first in aeson-1.4.6.0 but we're building against aeson-1.4.5.0
+formatRelativePath :: JSONPath -> String
+formatRelativePath = format ""
+  where
+    format :: String -> JSONPath -> String
+    format pfx []                = pfx
+    format pfx (Index idx:parts) = format (pfx ++ "[" ++ show idx ++ "]") parts
+    format pfx (Key key:parts)   = format (pfx ++ formatKey key) parts
+
+    formatKey :: Text -> String
+    formatKey key
+       | isIdentifierKey strKey = "." ++ strKey
+       | otherwise              = "['" ++ escapeKey strKey ++ "']"
+      where strKey = unpack key
+
+    isIdentifierKey :: String -> Bool
+    isIdentifierKey []     = False
+    isIdentifierKey (x:xs) = isAlpha x && all isAlphaNum xs
+
+    escapeKey :: String -> String
+    escapeKey = concatMap escapeChar
+
+    escapeChar :: Char -> String
+    escapeChar '\'' = "\\'"
+    escapeChar '\\' = "\\\\"
+    escapeChar c    = [c]

--- a/test/tasty/Data/Aeson/CommitTest.hs
+++ b/test/tasty/Data/Aeson/CommitTest.hs
@@ -8,37 +8,67 @@ import           Control.Applicative
 import           Data.Aeson.Commit
 import           Data.Aeson.QQ
 import           Data.Aeson.Types
+import           Data.Foldable       (toList)
 import           Data.Text           (Text)
 import           Test.Tasty.Hspec
 
 tests :: Spec
-tests = testParserWithCases pNested
-  [ ( "fails"
-    , [aesonQQ| {} |]
-    , Left $ unlines
-      [ "Error in $: No match,"
-      , "- key \"value\" not present"
-      , "- key \"nested\" not present"
-      ]
-    )
-  , ( "succeeds unnested"
-    , [aesonQQ| { value: "top" } |]
-    , Right "top"
-    )
-  , ( "succeeds and prefers nested"
-    , [aesonQQ| { value: "top" , nested: { value: "nest" } } |]
-    , Right "nest"
-    )
-  , ( "fails on malformed nested"
-    , [aesonQQ| { value: "top", nested: { foo: 9 } } |]
-    , Left "Error in $.nested: key \"value\" not present"
-    )
-  , ( "fails on nested type mismatch"
-    , [aesonQQ| { value: "top", nested: 9 } |]
-    , Left "Error in $.nested: parsing nestedObj failed, expected Object, but encountered Number"
-    )
-  ]
+tests = do
+  testParserWithCases pNested
+    [ ( "fails"
+      , [aesonQQ| {} |]
+      , Left $ unlines
+        [ "Error in $: No match,"
+        , "- key \"nested\" not present"
+        , "- key \"value\" not present"
+        ]
+      )
+    , ( "succeeds unnested"
+      , [aesonQQ| { value: "top" } |]
+      , Right "top"
+      )
+    , ( "succeeds and prefers nested"
+      , [aesonQQ| { value: "top" , nested: { value: "nest" } } |]
+      , Right "nest"
+      )
+    , ( "fails on malformed nested"
+      , [aesonQQ| { value: "top", nested: { foo: 9 } } |]
+      , Left "Error in $.nested: key \"value\" not present"
+      )
+    , ( "fails on nested type mismatch"
+      , [aesonQQ| { value: "top", nested: 9 } |]
+      , Left "Error in $.nested: parsing nestedObj failed, expected Object, but encountered Number"
+      )
+    ]
+  testParserWithCases parser2
+    [ ("fails with relative path"
+      , [aesonQQ| {"foo": {}} |]
+      , Left $ unlines
+        [ "Error in $: No match,"
+        , "- parsing array failed, expected Array, but encountered Object"
+        , "- .foo: key \"bar\" not present"
+        ]
+      )
+    , ("fails with nested relative path"
+      , [aesonQQ| {"foo": {"bar": ["hello"]}} |]
+      , Left $ unlines
+        [ "Error in $: No match,"
+        , "- parsing array failed, expected Array, but encountered Object"
+        , "- .foo.bar[0]: parsing Int failed, expected Number, but encountered String"
+        ]
+      )
+    , ("fails after commitment"
+      , [aesonQQ| [{}] |]
+      , Left "Error in $: parsing Int failed, expected Number, but encountered Object"
+      )
+    ]
   where
+    withKey :: FromJSON a => Text -> (a -> Parser b) -> Object -> Parser b
+    withKey key p o = o .: key >>= \v -> p v <?> Key key
+    parser2 :: Value -> Parser [Int]
+    parser2 v= runCommit $
+      commit (withArray "array" pure v) (fmap toList . traverse parseJSON)
+      <|> commit (withObject "object" (withKey "foo" (withKey "bar" parseJSON)) v) pure
     pNested :: Value -> Parser Text
     pNested = withObject "topLevel" $ \o ->
       runCommit


### PR DESCRIPTION
This PR modifies the error message handling to maintain all relevant `JSONPath`s when outputting the error after commitment fails.