### PR TITLE
Fix Nested Paths

### DIFF
--- a/aeson-commit.cabal
+++ b/aeson-commit.cabal
@@ -24,6 +24,7 @@ library
     , aeson
     , mtl
     , text
+    , unordered-containers
   ghc-options:
     -Wall
     -Wno-name-shadowing


### PR DESCRIPTION
Fix for path handling in #7 
Notes:
* does away with trying to find common paths. Just prints the whole path in each error
* leaves the parent parser to print the path up until the commit branch causing the errors
