### PR TITLE
Use CPS to preserve paths in subparser

### DIFF
--- a/aeson-commit.cabal
+++ b/aeson-commit.cabal
@@ -21,7 +21,7 @@ library
     src
   build-depends:
       base
-    , aeson
+    , aeson >= 1.4.6.0
     , mtl
     , text
     , unordered-containers

--- a/test/tasty/Data/Aeson/CommitTest.hs
+++ b/test/tasty/Data/Aeson/CommitTest.hs
@@ -5,7 +5,6 @@
 module Data.Aeson.CommitTest (tests) where
 
 import           Control.Applicative
-import           Control.Monad       ((>=>))
 import           Data.Aeson.Commit
 import           Data.Aeson.QQ
 import           Data.Aeson.Types
@@ -20,7 +19,7 @@ tests = do
       , Left $ unlines
         [ "Error in $: No match,"
         , "- key \"nested\" not found"
-        , "- key \"value\" not present"
+        , "- key \"value\" not found"
         ]
       )
     , ( "succeeds unnested"
@@ -33,7 +32,7 @@ tests = do
       )
     , ( "fails on malformed nested"
       , [aesonQQ| { value: "top", nested: { foo: 9 } } |]
-      , Left "Error in $.nested: key \"value\" not present"
+      , Left "Error in $.nested: key \"value\" not found"
       )
     , ( "fails on nested type mismatch"
       , [aesonQQ| { value: "top", nested: 9 } |]
@@ -63,7 +62,7 @@ tests = do
       )
     ]
   testParserWithCases
-    (\v -> withArray "arr" (overArray parser2) v)
+    (withArray "arr" (overArray parser2))
     [ ("path remains correct for a commit nested within another parser"
       , [aesonQQ| [ [1, 2, 3], {"foo": {"bar": ["hello"]}} ] |]
       , Left $ unlines

--- a/test/tasty/Data/Aeson/CommitTest.hs
+++ b/test/tasty/Data/Aeson/CommitTest.hs
@@ -79,6 +79,13 @@ tests = do
       , Left "Error in $.foo: parsing Int failed, expected Number, but encountered String"
       )
     ]
+  testParserWithCases
+    (runCommit . tryParser . objWithKey "bar" (objWithKey "foo" (parseJSON :: Value -> Parser Int)))
+    [ ("tryParser retains path on error"
+      , [aesonQQ| { "bar": {"foo": "fail"} } |]
+      , Left "Error in $.bar.foo: parsing Int failed, expected Number, but encountered String"
+      )
+    ]
   where
     parser2 :: Value -> Parser [Int]
     parser2 v = runCommit $


### PR DESCRIPTION
I have a concerns about the monadic implementation of `Commit`. To guarantee post-parsers correctly print paths, the pre-parser often needs to be repeated. For example:

```
runCommit $ commit (objWithKey "foo" (const $ pure v) v) (\v -> objWithKey "foo" parseJSON v :: Parser Int))
```

I think this code is more natural, and matches what the type of `commit` encourages, but the "foo" path will be entirely lost to `parseJSON` due to the implicit `>>=` in `commit`:

```
runCommit $ commit (objWithKey "foo" pure v) (parseJSON :: Value -> Parser Int))
```

To preserve paths, I tried in this PR an implementation of `commit` which makes the post parser an explicit subparser continuation. CPS makes for a less attractive interface, but it resembles what Aeson itself does to build nested parsers to preserve paths without using `>>=` and so combines well with functions already using this style such as `withObject`.
